### PR TITLE
49 feature/hook pre push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+# npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Récupérer tous les fichiers suivis (ajoutés/modifiés) avant le push
+files=$(git diff --staged --name-only --diff-filter=ACM) # A: Added, C: Copied, M: Modified
+
+for file in $files; do
+    # Vérifier si le fichier existe et est un fichier texte (évite les binaires)
+    if [[ -f "$file" ]] && [[ $(file --mime-type -b "$file") == text/* ]]; then
+        # Vérifier si le fichier contient "var_dump"
+        if grep -q "var_dump" "$file"; then
+            echo "❌ ERREUR : Le fichier '$file' contient un 'var_dump'."
+            echo "🚨 Supprimez tous les 'var_dump' avant de pousser votre code."
+            exit 1
+        fi
+    fi
+done
+
+echo "✅ Aucun 'var_dump' détecté. Poussée autorisée."
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@eslint/js": "^9.20.0",
         "eslint": "^9.20.1",
         "eslint-plugin-react": "^7.37.4",
-        "globals": "^15.15.0"
+        "globals": "^15.15.0",
+        "husky": "^9.1.7"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1416,6 +1417,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
-    "add-backup-remote": "git remote add backup https://github.com/MyGesDfu/Projet-Git-backup.git"
+    "add-backup-remote": "git remote add backup https://github.com/MyGesDfu/Projet-Git-backup.git",
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@eslint/js": "^9.20.0",
     "eslint": "^9.20.1",
     "eslint-plugin-react": "^7.37.4",
-    "globals": "^15.15.0"
+    "globals": "^15.15.0",
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
Description

Ajout d'un hook pre-push pour assurer la qualité du code avant chaque push. Ce hook permet d'exécuter des vérifications automatiques comme les tests unitaires et l'analyse statique du code.

Type de changement

Cochez les cases correspondantes au type de changement apporté :



Problèmes résolus

Cette PR ajoute une vérification automatique avant chaque push pour éviter l'envoi de code non conforme.

Comment tester ?

Ajouter le hook pre-push en exécutant chmod +x .git/hooks/pre-push.

Effectuer un commit puis tenter un git push.

Vérifier que les tests et l'analyse statique s'exécutent correctement.

Confirmer que le push est bloqué si des erreurs sont détectées.